### PR TITLE
If cannot get saml_metadata_conf_url from session, redirect to login

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -117,7 +117,11 @@ def _create_new_user(username, email, firstname, lastname):
 
 @csrf_exempt
 def acs(r):
-    saml_client = _get_saml_client(get_current_domain(r), r.session.get('saml_metadata_conf_url'))
+    saml_metadata_conf_url = r.session.get('saml_metadata_conf_url')
+    if not saml_metadata_conf_url:
+        return HttpResponseRedirect(get_reverse('login'))
+
+    saml_client = _get_saml_client(get_current_domain(r), saml_metadata_conf_url)
     resp = r.POST.get('SAMLResponse', None)
     next_url = r.session.get('login_next_url', get_reverse('admin:index'))
 


### PR DESCRIPTION
Currently if someone tries to get to the `/saml/acs/` page, it raises a server error. This fixes that by redirecting them instead to the login page.