### PR TITLE
Supporting for case-insensitive lookup of email for SSO login

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -210,7 +210,7 @@ def acs(r):
     try:
         # BEGIN TESORIO CHANGES
         # target_user = User.objects.get(username=user_name)
-        target_user = User.objects.get(email=user_email)
+        target_user = User.objects.get(email__iexact=user_email)
         # END TESORIO CHANGES
         if settings.SAML2_AUTH.get('TRIGGER', {}).get('BEFORE_LOGIN', None):
             import_string(settings.SAML2_AUTH['TRIGGER']['BEFORE_LOGIN'])(user_identity)


### PR DESCRIPTION
Fixes issues such as: https://sentry.io/organizations/tesorio/issues/2091543788/events/?project=154139

Where the user's email in their SSO provider is `ExampleJoe@tesorio.com` while in our product it is `examplejoe@tesorio.com`. This does not allow them to login. The workaround for the customer is to change their email in their SSO provider to be lowercase, but it's not ideal.