### PR TITLE
[MOVER-1714] Fix METADATA_INLINE not setting the metadata on get_saml_client

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -116,6 +116,8 @@ def _get_saml_client(domain, metadata_conf_url, metadata_conf_raw=None):
     # settings.SAML2_AUTH['METADATA_AUTO_CONF_URL'] = metadata_conf_url
     if metadata_conf_raw:
         metadata = {'inline': [metadata_conf_raw]}
+    elif 'METADATA_INLINE' in settings.SAML2_AUTH:
+        metadata = {'inline': [settings.SAML2_AUTH['METADATA_INLINE']]}
     else:
         metadata = {
             'remote': [


### PR DESCRIPTION
After a QA session with @datajockey , it was verified that `METADATA_INLINE` on the env var  was not setting the metadata correctly, leading to an error while trying to login with this  specific setting.